### PR TITLE
https://github.com/novatel/novatel_oem7_driver/issues/61

### DIFF
--- a/src/novatel_oem7_driver/config/std_msg_topics.yaml
+++ b/src/novatel_oem7_driver/config/std_msg_topics.yaml
@@ -1,9 +1,10 @@
 # ROS-standard
-IMU:        {topic: /gps/imu,                 frame_id: imu_link}
-RAWIMU:     {topic: /imu/data_raw,            frame_id: imu_link}
-GPSFix:     {topic: /gps/gps,                 frame_id: gps}
-NavSatFix:  {topic: /gps/fix,                 frame_id: gps} 
-Odometry:   {topic: /novatel/oem7/odom,       frame_id: odom} 
+IMU:          {topic: /gps/imu,                 frame_id: imu_link}
+RAWIMUOEM7:   {topic: /imu/data_raw/oem7,       frame_id: imu_link}
+RAWIMUREP105: {topic: /imu/data_raw/rep105,       frame_id: imu_link}
+GPSFix:       {topic: /gps/gps,                 frame_id: gps}
+NavSatFix:    {topic: /gps/fix,                 frame_id: gps} 
+Odometry:     {topic: /novatel/oem7/odom,       frame_id: odom} 
 
 # Oem7-specific 
 Oem7RawMsg:    {topic: /novatel/oem7/oem7raw,    frame_id: gps, queue_size: "200"}

--- a/src/novatel_oem7_driver/config/std_msg_topics.yaml
+++ b/src/novatel_oem7_driver/config/std_msg_topics.yaml
@@ -1,7 +1,7 @@
 # ROS-standard
 IMU:          {topic: /gps/imu,                 frame_id: imu_link}
 RAWIMUOEM7:   {topic: /imu/data_raw/oem7,       frame_id: imu_link}
-RAWIMUREP105: {topic: /imu/data_raw/rep105,       frame_id: imu_link}
+RAWIMUREP105: {topic: /imu/data_raw/rep105,     frame_id: imu_link}
 GPSFix:       {topic: /gps/gps,                 frame_id: gps}
 NavSatFix:    {topic: /gps/fix,                 frame_id: gps} 
 Odometry:     {topic: /novatel/oem7/odom,       frame_id: odom} 


### PR DESCRIPTION
Added an additional raw imu publisher that simply has remapped gyros. The original publisher (now dubbed OEM7) maintains the Novatel frame while the new publisher maintains rep105 conventions.

 #https://github.com/novatel/novatel_oem7_driver/issues/61
