### PR TITLE
Add undulation to UTM odometry z position to match NavSatFix altitude

### DIFF
--- a/src/novatel_oem7_driver/src/odometry_handler.cpp
+++ b/src/novatel_oem7_driver/src/odometry_handler.cpp
@@ -113,7 +113,7 @@ namespace novatel_oem7_driver
             double lon,
             double hgt)
     {
-      pt.z = hgt;
+      pt.z = hgt + inspvax_->undulation;
 
       // unused:
       bool northhp = false; 
@@ -154,7 +154,7 @@ namespace novatel_oem7_driver
 
     void publishOdometry()
     {
-      if(!gpsfix_)
+      if(!gpsfix_ || !inspvax_)
       {
         // No data to derive basic Odometry values
         return;


### PR DESCRIPTION
Hello! I noticed an altitude reference discrepancy between the `z` position component of the UTM odometry output and the altitude in the `NavSatFix` output.

This PR proposes that the UTM `z` position should be ellipsoidal height to match `NavSatFix` by adding undulation to the geoidal height.