### PR TITLE
Make sure rosdep checks for EoL distros (foxy) during build.

### DIFF
--- a/create-binary-package.sh
+++ b/create-binary-package.sh
@@ -4,7 +4,7 @@ UBUNTU_TGT_DISTRO=$1
 ROS_TGT_DISTRO=$2
 
 echo build | sudo -S rosdep init # this usually fails with harmless error
-rosdep update
+rosdep update --include-eol-distros
 
 rm *.deb
 rm src/*.deb


### PR DESCRIPTION
Currently, rosdep will not fetch dependencies correctly when building the .deb packages for foxy.
As foxy is now EoL, rosdep will only fetch the dependencies if specifically told to with `--include-eol-distros`.
This pull request simply makes sure that `rosdep update` is called with this option when building.