### PR TITLE
Add missing git dependency

### DIFF
--- a/src/novatel_oem7_driver/package.xml
+++ b/src/novatel_oem7_driver/package.xml
@@ -11,6 +11,7 @@
   <url type="website">http://www.novatel.com</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>git</buildtool_depend>
   
   <depend>pluginlib</depend>
   <depend>boost</depend>


### PR DESCRIPTION
Git is used to clone the driver in the CmakeLists.txt. And should therefor be listed as a dependency