### PR TITLE
Decrease boost dependency

### DIFF
--- a/src/novatel_oem7_driver/CMakeLists.txt
+++ b/src/novatel_oem7_driver/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(nmea_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(novatel_oem7_msgs REQUIRED)
-find_package(Boost  			REQUIRED)
+find_package(Boost REQUIRED COMPONENTS headers)
 
 LIST(APPEND CMAKE_MODULE_PATH "/usr/share/cmake/geographiclib")
 
@@ -110,7 +110,7 @@ add_executable(${PROJECT_NAME}_exe
 message(STATUS "Linking to EDIE at: '${CMAKE_BINARY_DIR}'")
 
 target_link_libraries(${PROJECT_NAME}
-   Boost::boost
+   Boost::headers
    ${GeographicLib_LIBRARIES}
    ${CMAKE_BINARY_DIR}/usr/lib/libCommon.a
    ${CMAKE_BINARY_DIR}/usr/lib/libStreamInterface.a

--- a/src/novatel_oem7_driver/package.xml
+++ b/src/novatel_oem7_driver/package.xml
@@ -13,8 +13,9 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>git</buildtool_depend>
   
+  <build_depend>libboost-dev</build_depend>
+
   <depend>pluginlib</depend>
-  <depend>boost</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>gps_msgs</depend>


### PR DESCRIPTION
I'm trying to minimize the deployed binary size on our robot, and the boost headers are quite big. This package only uses a couple of boost headers, and doesn't use any boost dynamic linked libraries. This means we only need a `<build_depend>` on boost.