### PR TITLE
Fix ISA-100C (IMU type 26) output rate: 100 -> 200 Hz

### DIFF
--- a/src/novatel_oem7_driver/config/oem7_supported_imus.yaml
+++ b/src/novatel_oem7_driver/config/oem7_supported_imus.yaml
@@ -10,7 +10,7 @@ supported_imus:
    "16" : { name:  "KVH CPT IMU",                                  rate: 200   }
    "19" : { name:  "Northrop Grumman Litef LCI-1",                 rate: 200   }
    "20" : { name:  "Honeywell HG1930 AA99",                        rate: 100   }
-   "26" : { name:  "Northrop Grumman Litef ISA-100C",              rate: 100   }
+   "26" : { name:  "Northrop Grumman Litef ISA-100C",              rate: 200   }
    "27" : { name:  "Honeywell HG1900 CA50",                        rate: 100   }
    "28" : { name:  "Honeywell HG1930 CA50",                        rate: 100   }
    "31" : { name:  "Analog Devices ADIS16488",                     rate: 200   }


### PR DESCRIPTION
## Summary

`config/oem7_supported_imus.yaml` maps IMU type 26 (Northrop Grumman Litef **ISA-100C**) to `rate: 100`, but per NovAtel's own OEM7 documentation the ISA-100C outputs at **200 Hz**. Because this rate is used as a linear multiplier when converting the raw IMU data to physical units, an ISA-100C receiver running in auto-detect mode (`oem7_imu_rate: 0`) emits IMU angular velocity **and** linear acceleration at **half** the true magnitude.

```diff
-   "26" : { name:  "Northrop Grumman Litef ISA-100C",              rate: 100   }
+   "26" : { name:  "Northrop Grumman Litef ISA-100C",              rate: 200   }
```

## Why the rate matters

The raw-IMU conversion multiplies by the IMU rate:

- RAWIMUSX path (`ins_handler.cpp`): `angular_velocity = raw_gyro * gyro_scale * imu_rate_`
- CORRIMU path (`ins_handler.cpp`): `factor = imu_rate_ / imu_data_count; angular_velocity = corrimu_->yaw_rate * factor`

This matches the RAWIMUSX documentation: *"To obtain acceleration in m/s/s or rotation rate in rad/s, multiply the velocity/rotation increments by the output rate of the IMU."* For the ISA-100C the gyro/accel scale factors are rate-independent constants (`1.0E-9`, `2.0E-8`), so the output is directly proportional to `imu_rate_`. `imu_rate_` comes from `oem7_imu_rate` when overridden, otherwise from `supported_imus.<type>.rate` in this YAML — so in auto mode the wrong table value is used directly.

## Evidence that ISA-100C is 200 Hz

1. **NovAtel documentation** — RAWIMUX lists the ISA-100C among the 200 Hz IMUs (with LN-200, µIMU-IC, P1750, EG370N, EG320N_200Hz); HG4930/CPT7 are the 100 Hz group.
   - https://docs.novatel.com/OEM7/Content/SPAN_Logs/RAWIMUX.htm
   - https://docs.novatel.com/OEM7/Content/SPAN_Logs/RAWIMUSX.htm#RawIMUScaleFactors
2. **Hardware** — On a PwrPak7 + ISA-100C, CORRIMUDATA is published at ~100 Hz with `imu_data_count = 2`, i.e. an IMU sample rate of 100 × 2 = **200 Hz**. (On the same setup an HG4930 receiver publishes CORRIMUDATA at ~100 Hz with `imu_data_count = 1` → 100 Hz, consistent with its table entry.)
3. **On-vehicle A/B** — With the corrected table value (200 Hz) selected via auto mode, the driver's ISA-100C angular rate matches the receiver's own INS solution yaw rate to within 0.1% (ratio ≈ 1.00) during rotation. With the shipped value (100 Hz) the output would be exactly half.

## Secondary observation (not changed here — please confirm)

Type **58 "Honeywell HG4930 AN01"** is listed at `rate: 200`, but the RAWIMUX documentation groups all non-400 Hz HG4930 variants (AN01/AN04, CPT7, CPT7700) at **100 Hz** (type 68 `HG4930_AN04` is already 100; type 69 is the 400 Hz variant). This looks inconsistent as well, but we have not verified it on AN01 hardware and left it unchanged.

## Note on the root cause

The driver derives the IMU rate from a static table rather than from the `INSCONFIG` message, so a wrong table entry can only be worked around with a manual per-node `oem7_imu_rate` override — easy to misapply when two receivers with different IMUs share a launch file. Correcting the table entry is the minimal fix.
